### PR TITLE
Updating requirements to be able to setup project dependencies with no issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ incremental==17.5.0
 isort==4.3.4
 Jinja2==2.10
 lazy-object-proxy==1.3.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 msgpack==0.5.6
 mysqlclient==1.3.12
@@ -47,4 +47,4 @@ typed-ast==1.1.0
 typing==3.6.4
 urllib3==1.23
 wrapt==1.10.11
-zope.interface==4.5.0
+zope.interface==5.1.0


### PR DESCRIPTION
## Purpose :muscle:
A couple of dependencies previously freezed were failing to be installed when just running `pip install -r requirements`: `MarkupSafe` and `zope.interface`
So after updating them, and recreating from zero the project with updated `requirements.txt.` it successfully installed all dependencies.

## Changes required (Database, config, etc)
Recreate your virtual env:
1. `deactive` the virtual env being used
2. Re create it using `virtualenv [env name]`
3. `pip install -r requirements`
