### PR TITLE
Adding .travis.yml to use Travis as CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+notifications:
+  email: false


### PR DESCRIPTION
## Purpose :muscle:

Adding Travis as CI server.

## Why Travis?

Is a simple and well know CI
It is free
It is used by the Django ecosystem, like in https://github.com/encode/django-rest-framework