### PR TITLE
Removing skills and education fields

### DIFF
--- a/on_demand/migrations/0001_initial.py
+++ b/on_demand/migrations/0001_initial.py
@@ -46,7 +46,6 @@ class Migration(migrations.Migration):
             name='SupplierProfile',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('skills', models.TextField(blank=True, null=True)),
                 ('finished_connections_count', models.IntegerField(default=0)),
                 ('connections_ranking_accumulator', models.IntegerField(default=0)),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now)),
@@ -69,7 +68,6 @@ class Migration(migrations.Migration):
                 ('facebook', models.TextField(blank=True, null=True)),
                 ('youtube', models.TextField(blank=True, null=True)),
                 ('description', models.TextField(blank=True, null=True)),
-                ('education', models.TextField(blank=True, null=True)),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now)),
                 ('user', models.OneToOneField(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='details', to=settings.AUTH_USER_MODEL)),
             ],

--- a/on_demand/migrations/0002_create_index.py
+++ b/on_demand/migrations/0002_create_index.py
@@ -9,8 +9,7 @@ def forwards(apps, schema_editor):
       print('Skipping migration without attempting to ADD FULL TEXT SEARCH')
       return
 
-  migrations.RunSQL('ALTER TABLE on_demand_supplier_profile ADD FULLTEXT (skills)')
-  migrations.RunSQL('ALTER TABLE on_demand_userdetails ADD FULLTEXT (description, education)')
+  migrations.RunSQL('ALTER TABLE on_demand_userdetails ADD FULLTEXT (description)')
 
 class Migration(migrations.Migration):
 

--- a/on_demand/models.py
+++ b/on_demand/models.py
@@ -24,7 +24,6 @@ class UserDetails(models.Model):
     facebook = models.TextField(blank=True, null=True)
     youtube = models.TextField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
-    education = models.TextField(blank=True, null=True)
     date_joined = models.DateTimeField(default=timezone.now)
 
 
@@ -35,7 +34,6 @@ class SupplierProfile(models.Model):
         related_name='supplier_profile',
         null=True
     )
-    skills = models.TextField(blank=True, null=True)
     finished_connections_count = models.IntegerField(default=0)
     connections_ranking_accumulator = models.IntegerField(default=0)
     date_joined = models.DateTimeField(default=timezone.now)

--- a/on_demand/serializers.py
+++ b/on_demand/serializers.py
@@ -7,7 +7,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserDetails
         fields = ('email', 'picture', 'linkedin', 'behance', 'twitter',
-                  'instagram', 'facebook', 'youtube', 'description', 'education')
+                  'instagram', 'facebook', 'youtube', 'description')
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -31,7 +31,7 @@ class SupplierProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SupplierProfile
-        fields = ('skills', 'user_id', 'user',
+        fields = ('user_id', 'user',
                   'finished_connections_count', 'connections_ranking_accumulator')
 
 

--- a/on_demand/views/search_views.py
+++ b/on_demand/views/search_views.py
@@ -15,7 +15,7 @@ def newest_suppliers(request):
     Retrieve the five newest suppliers that joined, nesting user data
     """
     supplier_profiles = SupplierProfile.objects.select_related('user').filter(user__first_name__isnull=False, user__last_name__isnull=False,
-                                                                              user__details__education__isnull=False, user__details__description__isnull=False, skills__isnull=False).order_by('-date_joined')[:30]
+                                                                              user__details__description__isnull=False).order_by('-date_joined')[:30]
     supplier_serializer = SupplierProfileSerializer(
         supplier_profiles, many=True)
     return Response(supplier_serializer.data)
@@ -27,8 +27,7 @@ def find_suppliers(request):
     decoded_search_term = urllib.parse.unquote(search_term)
     search_query_tables = "SELECT * FROM api_supplier_profile M LEFT JOIN auth_user U ON M.user_id = U.id LEFT JOIN api_userdetails P ON P.user_id = U.id WHERE "
     search_query_names_like = "U.first_name LIKE %s OR U.last_name LIKE %s OR "
-    search_query_full_text_profile = "MATCH (P.description,P.education) AGAINST (%s IN NATURAL LANGUAGE MODE)"
-    search_query_full_text_supplier_profile = " OR MATCH (M.skills) AGAINST (%s IN NATURAL LANGUAGE MODE)"
+    search_query_full_text_profile = "MATCH (P.description) AGAINST (%s IN NATURAL LANGUAGE MODE)"
     complete_search_query = search_query_tables + search_query_names_like + \
         search_query_full_text_profile + search_query_full_text_supplier_profile
     results = SupplierProfile.objects.raw(


### PR DESCRIPTION
## Purpose :muscle:

Both `skills` and `education` fields are oriented to a data model that may be not useful for every case. They are not those kind of generic fields that apply to the majority of on demand api use cases.
