### PR TITLE
Fixing Find Suppliers method with corresponding tests

### DIFF
--- a/on_demand/urls.py
+++ b/on_demand/urls.py
@@ -18,6 +18,6 @@ urlpatterns = [
     url(r'^users/(?P<user_id>[0-9]+)/consumer-profile',
         consumer_profile_views.consumer_profile, name='consumer-profile'),
     url('newest-suppliers', search_views.newest_suppliers, name='newest-suppliers'),
-    url(r'^find-suppliers/$', search_views.find_suppliers),
+    url(r'^find-suppliers/$', search_views.find_suppliers, name='find-suppliers'),    # Example: /find-suppliers/?search_term=something_to_search
     url('', include(router.urls))
 ]


### PR DESCRIPTION
## Purpose :muscle:

Fixing `find-suppliers` method. Testing revealed that was not working at all. Also was too hardcoded. 
Now `find-suppliers` searches using `first_name` and `last_name` if db is **not** MySQL. If MySQL engine is being used, then also FULL TEXT SEARCH if performed using `description` field.
NOTE: Full Text search over `description`  field will not be tested since SQLite does not support `ALTER TABLE` to add FTS on an existing table.
